### PR TITLE
[WIP] Cache / Download Images

### DIFF
--- a/components/pageList.js
+++ b/components/pageList.js
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Dimensions, FlatList, View, Text, Image,
+import { Dimensions, FlatList, View, Text, Image as RNImage,
   TouchableWithoutFeedback } from 'react-native'
+import { Image } from 'react-native-expo-image-cache'
 import { inject, observer } from 'mobx-react'
 
 import { getImage } from '../models/api.js'
@@ -105,7 +106,7 @@ class Page extends React.PureComponent {
     const { page } = this.props
     getImage(page).then((image) => {
       this.setState({ image })
-      Image.getSize(image, (imageWidth, imageHeight) =>
+      RNImage.getSize(image, (imageWidth, imageHeight) =>
         this.setState({ imageWidth, imageHeight })
       )
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -2559,6 +2559,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -6384,6 +6389,14 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-2.2.5.tgz",
       "integrity": "sha1-QHTdY7SXPmOX2c5Q6XtXx3pRjp0="
+    },
+    "react-native-expo-image-cache": {
+      "version": "github:agilgur5/react-native-expo-image-cache#15ac11aad7eb9974b125c5961f8c769a58fd8bf0",
+      "from": "github:agilgur5/react-native-expo-image-cache",
+      "requires": {
+        "crypto-js": "^3.1.9-1",
+        "lodash": "^4.17.4"
+      }
     },
     "react-native-gesture-handler": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "mobx-state-tree": "^3.14.0",
     "mst-persist": "github:agilgur5/mst-persist",
     "react": "16.3.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-29.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-29.0.0.tar.gz",
+    "react-native-expo-image-cache": "github:agilgur5/react-native-expo-image-cache"
   },
   "devDependencies": {
     "react-devtools": "^3.2.3"


### PR DESCRIPTION
Still getting bugs with `react-native-expo-image-cache`, even on my fork. Might be a Babel 7 thing.

This is still not ideal as caching is a bit different than the standard reader app functionality of "download / save for later". Long-term storage and unnecessary storage are issues. The other issue is that at least some sites have signed/timestamped images; if they're cached, they won't expire by timestamp of course, but retrieving the image might not hit the cache.

This likely needs a more custom solution with `FilesystemStorage`, which would be way more effort. The timestamp concerns and general restructuring of how pages/images are retrieved also requires more integrations with different sites to see how different ones do it.