### PR TITLE
Add Read/Unread and New chapter indicators to Chapter List

### DIFF
--- a/components/chapterList.js
+++ b/components/chapterList.js
@@ -65,12 +65,16 @@ export default class ChapterList extends React.Component {
   }
 }
 
-class Chapter extends React.PureComponent {
+@observer
+class Chapter extends React.Component {
   render () {
     const { chapter } = this.props
+    const chapterStyle = chapter.read
+      ? styles.chapter
+      : { ...styles.chapter, ...styles.chapterUnread }
 
     return <TouchableWithoutFeedback onPress={this.onSelect}>
-      <View style={styles.chapter}>
+      <View style={chapterStyle}>
         <Text style={styles.chapterTitle}>
           CHAPTER {chapter.title}
         </Text>

--- a/components/chapterList.js
+++ b/components/chapterList.js
@@ -78,6 +78,10 @@ class Chapter extends React.Component {
         <Text style={styles.chapterTitle}>
           CHAPTER {chapter.title}
         </Text>
+        {chapter.isNew() && <Text style={styles.newText}>New!</Text>}
+        <Text style={styles.date}>
+          {chapter.date && chapter.date.toLocaleDateString()}
+        </Text>
       </View>
     </TouchableWithoutFeedback>
   }

--- a/components/chapterStyles.js
+++ b/components/chapterStyles.js
@@ -7,6 +7,8 @@ const styles = {
     right: 0,
     backgroundColor: '#333'
   },
+
+  // nav styles
   navBar: {
     width: '100%',
     height: 34
@@ -24,6 +26,8 @@ const styles = {
     fontSize: 30,
     color: 'gray'
   },
+
+  // manga desc styles
   header: {
     flexDirection: 'row',
     maxHeight: 349,
@@ -61,7 +65,10 @@ const styles = {
     fontSize: 16,
     lineHeight: 20
   },
+
+  // chapter list styles
   chapter: {
+    flexDirection: 'row',
     padding: 16,
     backgroundColor: '#333',
     borderBottomWidth: 1,
@@ -75,6 +82,20 @@ const styles = {
     lineHeight: 16,
     fontWeight: '900',
     color: '#fff'
+  },
+  newText: {
+    marginLeft: 6,
+    fontSize: 14,
+    lineHeight: 16,
+    fontWeight: '900',
+    color: '#8ca0d1' // pale blue
+  },
+  date: {
+    marginLeft: 'auto', // right align
+    fontSize: 14,
+    lineHeight: 16,
+    fontWeight: '700', // smaller than rest as not as important
+    color: '#ddd' // v. light gray
   }
 }
 

--- a/components/chapterStyles.js
+++ b/components/chapterStyles.js
@@ -67,6 +67,9 @@ const styles = {
     borderBottomWidth: 1,
     borderColor: 'rgba(0, 0, 0, 0.3)'
   },
+  chapterUnread: {
+    backgroundColor: '#555'
+  },
   chapterTitle: {
     fontSize: 14,
     lineHeight: 16,

--- a/models/models.js
+++ b/models/models.js
@@ -96,7 +96,14 @@ const Manga = types.model('Manga', {
 }).actions((self) => ({
   loadChapters: flow(function * loadChapters () {
     const { chapters, tags, summary } = yield getChapters(self.link)
-    self.chapters = chapters
+    if (self.chapters.length === 0) {
+      self.chapters = chapters // just an optimization compared to below
+    } else {
+      // merge chapter data if some already persisted
+      chapters.forEach((chapter, index) => {
+        self.chapters[index] = { ...self.chapters[index], ...chapter }
+      })
+    }
     self.tags = tags
     self.summary = summary
   })
@@ -105,10 +112,12 @@ const Manga = types.model('Manga', {
 const Chapter = types.model('Chapter', {
   link: types.identifier,
   title: types.string,
+  read: false,
   pages: types.array(types.late(() => Page))
 }).actions((self) => ({
   loadPages: flow(function * loadPages () {
     self.pages = yield getPages(self.link)
+    self.read = true
   })
 }))
 

--- a/models/models.js
+++ b/models/models.js
@@ -1,6 +1,7 @@
 import { types, flow } from 'mobx-state-tree'
 
 import { getLatest, getSearch, getChapters, getPages } from './api.js'
+import { nextDay } from '../utils/dateHelpers.js'
 
 const AppModel = types.model('App', {
   isHorizontal: true,
@@ -112,9 +113,15 @@ const Manga = types.model('Manga', {
 const Chapter = types.model('Chapter', {
   link: types.identifier,
   title: types.string,
+  date: types.maybeNull(types.Date), // can be non-existent or invalid
   read: false,
   pages: types.array(types.late(() => Page))
-}).actions((self) => ({
+}).views((self) => ({
+  isNew () {
+    // less than a week old
+    return self.date && self.date > nextDay(new Date(), -7)
+  }
+})).actions((self) => ({
   loadPages: flow(function * loadPages () {
     self.pages = yield getPages(self.link)
     self.read = true

--- a/utils/dateHelpers.js
+++ b/utils/dateHelpers.js
@@ -1,0 +1,9 @@
+export function dupDate (date) {
+  return new Date(date.valueOf())
+}
+
+export function nextDay (date, days = 1) {
+  const newDate = dupDate(date)
+  newDate.setDate(date.getDate() + days)
+  return newDate
+}


### PR DESCRIPTION
Fixes #7 

Adds:
- Read/Unread indicator as light v. dark highlight, similar to Gmail
- Release Dates for each chapter right-aligned in chapter list
- "New!" in pale blue to the right of each Chapter name/number
  - New meaning less than 1 week old for now

To add in Future PRs:
- Don't mark as read if quickly hit back (or only read like a few pages or something)
- Ability to mark chapters as read or unread
  - Bulk mark chapters read/unread
- Update Chapter Lists in Background or in Manga List view
  - Highlight mangas which have unread, new chapters
  - Possibly send local notification if in background?