### PR TITLE
v0.2.1 -- bugfixes for loading new chapters

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "slug": "react-native-manga-reader-app",
     "privacy": "public",
     "sdkVersion": "33.0.0",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "platforms": [
       "ios",
       "android"

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,2 +1,0 @@
-# don't commit any site specific data
-scraperDrivers/

--- a/models/scraperDrivers/.gitignore
+++ b/models/scraperDrivers/.gitignore
@@ -1,0 +1,3 @@
+# don't commit site names or URLs for now
+allDrivers.js
+driver*URLS.js

--- a/models/scraperDrivers/driver1.js
+++ b/models/scraperDrivers/driver1.js
@@ -1,0 +1,52 @@
+export { searchURL, latestURL } from './driver1URLs.js'
+
+export function getSearch ($) {
+  return $('.post-list li')
+    .map((index, el) => ({
+      link: $(el).find('a').attr('href'),
+      title: $(el).find('img').attr('title'),
+      cover: $(el).find('img').attr('src')
+    }))
+    .get()
+}
+
+export function getLatest ($) {
+  return $('.post')
+    .map((index, el) => ({
+      link: $(el).find('a').attr('href'),
+      title: $(el).find('img').attr('title'),
+      cover: $(el).find('img').attr('src'),
+      release: $(el).find('em').text()
+    }))
+    .get()
+}
+
+export function getChapters ($) {
+  const title = $('.manga-detail-top .title').text().trim()
+  const chapters = $('.chlist a')
+    .map((index, el) => {
+      return {
+        link: $(el).attr('href').replace('//', 'http://'),
+        title: $(el).text().match(/[0-9]+/)[0] || '0',
+        date: new Date($(el).find(':not(.newch)').text())
+      }
+    })
+    .get()
+  const tags = $('.manga-genres li')
+    .map((index, el) => $(el).text().trim())
+    .get()
+  const summary = $('.manga-summary').text().trim()
+  return { title, chapters, tags, summary }
+}
+
+export function getPages ($) {
+  return $('.mangaread-page option')
+    .map((index, el) => ({
+      link: $(el).attr('value').replace('//', 'http://')
+    }))
+    .get()
+}
+
+export function getImage ($) {
+  return $('#viewer img').attr('src')
+}

--- a/models/scraperDrivers/driver1.js
+++ b/models/scraperDrivers/driver1.js
@@ -25,10 +25,17 @@ export function getChapters ($) {
   const title = $('.manga-detail-top .title').text().trim()
   const chapters = $('.chlist a')
     .map((index, el) => {
+      const dateText = $(el).find(':not(.newch)').text()
+      // if "hours ago". "days ago", "Today", etc, just use now
+      const isRelative = dateText.includes('ago') ||
+        dateText.includes('Today') ||
+        dateText.includes('Yesterday')
+      const date = new Date(isRelative ? Date.now() : dateText)
+
       return {
         link: $(el).attr('href').replace('//', 'http://'),
         title: $(el).text().match(/[0-9]+/)[0] || '0',
-        date: new Date($(el).find(':not(.newch)').text())
+        date
       }
     })
     .get()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-manga-reader-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-manga-reader-app",
   "description": "A React Native / Expo app for cross-platform manga reading",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
- (fix): ensure certain relative dates can be parsed -- fixes #20 
  - this is the simple fix to #20 as I don't think parsing the relative dates more accurately is high priority / worth the time right now
    - most libraries that handle this are quite large as well, don't think the added bundle size is currently a worthwhile trade-off
- (fix): ensure new chapters are merged properly -- fixes #21 
  - this is the simple fix to #21 as migrating the data to a map format is dependent on at least https://github.com/agilgur5/mst-persist/pull/16 which will allow one to add migrations on top

A slightly big change is that, in the process of this PR, I've exposed much of the scraper driver code that is specific to scraping / parsing so that it can be version controlled (as well as used as an example for forks, custom providers, etc -- see #1). A small portion is still private for now. Once more providers are added (#6), I think it would be wise to consider extracting this logic into its own "SDK" of sorts and just have the app use the SDK. Still unsure how safe-listing and custom providers etc might work though, but I do think that logic is independent enough to be split out, the goal of this app is to just be a reader -- where & how it reads is not a central concern (so long as it supports user needs/wants).
