### PR TITLE
v0.3.0 - Indicate new unread chapters

### DIFF
--- a/App.js
+++ b/App.js
@@ -15,6 +15,9 @@ persist('@mangaStoreKey', appStore, {
     'mangas',
     'favorites'
   ]
+}).then(() => {
+  // fetch chapters on app load so that numNewUnread is updated
+  appStore.loadFavoritesChapters()
 })
 
 const App = () => (

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "slug": "react-native-manga-reader-app",
     "privacy": "public",
     "sdkVersion": "33.0.0",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "platforms": [
       "ios",
       "android"

--- a/components/mangaList.js
+++ b/components/mangaList.js
@@ -31,9 +31,16 @@ export default class MangaList extends React.Component {
   }
 }
 
-class Manga extends React.PureComponent {
+@observer
+class Manga extends React.Component {
   render () {
     const { manga } = this.props
+    // show either the number of new unread chapters if available or
+    // "Today" / "Yesterday" if available
+    const newText = manga.numNewUnreadChapters()
+      ? manga.numNewUnreadChapters() + ' new unread chapters'
+      : manga.release && manga.release.toUpperCase()
+    const isNew = manga.numNewUnreadChapters() || manga.release === 'Today'
 
     return <TouchableWithoutFeedback onPress={this.onSelect}>
       <View style={styles.manga}>
@@ -45,10 +52,10 @@ class Manga extends React.PureComponent {
         <Text
           style={{
             ...styles.release,
-            color: manga.release === 'Today' ? '#fff' : '#aaa'
+            color: isNew ? '#fff' : '#aaa'
           }}
         >
-          {manga.release && manga.release.toUpperCase()}
+          {newText}
         </Text>
       </View>
     </TouchableWithoutFeedback>

--- a/components/mangaStyles.js
+++ b/components/mangaStyles.js
@@ -34,7 +34,7 @@ const styles = {
     paddingLeft: 4,
     paddingRight: 4,
     color: '#fff',
-    fontSize: 10,
+    fontSize: 12,
     lineHeight: 16,
     fontWeight: '500'
   }

--- a/models/models.js
+++ b/models/models.js
@@ -90,6 +90,10 @@ const AppModel = types.model('App', {
     self.favorites.splice(self.favorites.findIndex((elem) => {
       return elem === self.selectedManga
     }), 1)
+  },
+
+  loadFavoritesChapters () {
+    self.favorites.forEach((favorite) => favorite.loadChapters())
   }}
 })
 

--- a/models/models.js
+++ b/models/models.js
@@ -101,7 +101,15 @@ const Manga = types.model('Manga', {
   chapters: types.array(types.late(() => Chapter)),
   tags: types.array(types.string),
   summary: ''
-}).actions((self) => ({
+}).views((self) => ({
+  numNewUnreadChapters () {
+    let sum = 0
+    self.chapters.forEach((chapter) => {
+      if (chapter.isNew() && !chapter.read) sum++
+    })
+    return sum
+  }
+})).actions((self) => ({
   loadChapters: flow(function * loadChapters () {
     const { chapters, tags, summary } = yield getChapters(self.link)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-manga-reader-app",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-manga-reader-app",
   "description": "A React Native / Expo app for cross-platform manga reading",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
- show the number of new unread chapters in the manga list view so it's visible at a glance without having to click into the chapter list view
- fetch chapters on app load so that the above number is updated on load, allowing users to know immediately if there are any new unread chapters without having to click into the chapter list view to fetch the new chapters

This is like the MVP / first phase of #18 . After this, now that we have indicators in-app and fetch chapters on app load, we can move on to fetching in background and having notifications out-of-app.