### PR TITLE
v0.2.2 -- (hotfix): merge persisted mangas with fetched ones

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "slug": "react-native-manga-reader-app",
     "privacy": "public",
     "sdkVersion": "33.0.0",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "platforms": [
       "ios",
       "android"

--- a/models/models.js
+++ b/models/models.js
@@ -18,14 +18,21 @@ const AppModel = types.model('App', {
     return self.favorites.includes(self.selectedManga)
   }
 })).actions((self) => {
+  // private helper functions
+  function mergeManga (manga) {
+    const oldManga = self.mangas.get(manga.link)
+    self.mangas.put({...oldManga, ...manga})
+  }
+
   function addMangas (mangas) {
-    mangas.forEach(manga => self.mangas.put(manga))
+    mangas.forEach(mergeManga)
   }
 
   function mangasToRefs (mangas) {
     return mangas.map(({link}) => link)
   }
 
+  // public actions
   return {toggleHorizontal () {
     self.isHorizontal = !self.isHorizontal
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-manga-reader-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-manga-reader-app",
   "description": "A React Native / Expo app for cross-platform manga reading",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
- previously fetched mangas would just overwrite the existing mangas
  - now that we have important data like chapter read/unread & new
    tracking, we can't just overwrite, have to merge them together

- this is a bit of an edge case as the only time there's a conflict is
  when a favorited manga also appears in the Latest or Search list
  - but it certainly does happen, I just experienced it!
    - had chapters overwritten to an empty list bc manga was in Latest

The merge logic here is similar to that used in #23 -- running into similar merging issues in a few places 😅 Should really write some tests eventually, at least for the store, with some fake data to test for all these persistence edge cases