### PR TITLE
v0.3.1 -- Improve search input UX

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "slug": "react-native-manga-reader-app",
     "privacy": "public",
     "sdkVersion": "33.0.0",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "platforms": [
       "ios",
       "android"

--- a/components/mainView.js
+++ b/components/mainView.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { StatusBar, View, Text, TextInput, SectionList } from 'react-native'
 import { inject, observer } from 'mobx-react'
+import debounce from 'lodash.debounce'
 
 import MangaList from './mangaList.js'
 import PageList from './pageList.js'
@@ -42,7 +43,7 @@ export default class MainView extends React.Component {
         sections={[
           {
             title: 'Search...',
-            props: { onChangeText: submitQuery },
+            props: { onChangeText: debounce(submitQuery, 200) },
             data: [{ mangas: searched, onSelect: selectManga }]
           },
           {

--- a/components/mainView.js
+++ b/components/mainView.js
@@ -20,7 +20,8 @@ export default class MainView extends React.Component {
     switch (section.title) {
       case 'Search...':
         return <TextInput style={styles.text} placeholder='Search...'
-          placeholderTextColor={styles.text.color} {...section.props} />
+          placeholderTextColor={styles.text.color} autoCorrect={false}
+          {...section.props} />
       case 'Favorites':
         return <Text style={styles.text}>Favorites</Text>
       case 'Latest':

--- a/package-lock.json
+++ b/package-lock.json
@@ -5459,6 +5459,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.pad": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-manga-reader-app",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-manga-reader-app",
   "description": "A React Native / Expo app for cross-platform manga reading",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "cheerio-without-node-native": "^0.20.2",
     "expo": "^33.0.0",
+    "lodash.debounce": "^4.0.8",
     "mobx": "^5.9.4",
     "mobx-react": "^5.2.5",
     "mobx-state-tree": "^3.14.0",


### PR DESCRIPTION
- disables autocorrect (and spellcheck) on search bc lots of japanese romanized words
  - autocorrect and spellcheck are by default turned _on_, and turning off autocorrect automatically disables spellcheck as well
- debounces search input for a more steady UX and less wasted network usage

Had been meaning to do this for a while and finally got annoyed by it enough (and curious if there were an autocorrect setting in RN like there is on web) to actually change the code, which is basically just 2 one-liners.